### PR TITLE
Support array initialization via for-loop expressions

### DIFF
--- a/backend/cmake/CHPLX_Compile.cmake
+++ b/backend/cmake/CHPLX_Compile.cmake
@@ -182,6 +182,22 @@ function(chplx_compile_project name)
     set(generator_toolset -T ${CMAKE_GENERATOR_TOOLSET})
   endif()
 
+  if(NOT fmt_DIR AND CHPLX_WITH_TESTS)
+    if(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/cmake/fmt")
+      message(STATUS "Using fmt from ${CMAKE_INSTALL_PREFIX}/lib/cmake/fmt")
+      set(fmt_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake/fmt" CACHE PATH
+          "Path to fmt CMake configuration files")
+    endif()
+  endif()
+
+  if(NOT HPX_DIR AND CHPLX_WITH_TESTS)
+    if(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/cmake/HPX")
+      message(STATUS "Using HPX from ${CMAKE_INSTALL_PREFIX}/lib/cmake/HPX")
+      set(HPX_DIR "${CMAKE_INSTALL_PREFIX}/lib/cmake/HPX" CACHE PATH
+          "Path to HPX CMake configuration files")
+    endif()
+  endif()
+
   add_custom_command(
     COMMAND ${CMAKE_COMMAND} . -B ./build
         -G ${CMAKE_GENERATOR} ${generator_toolset}

--- a/backend/include/hpx/programtree.hpp
+++ b/backend/include/hpx/programtree.hpp
@@ -245,6 +245,8 @@ struct ForLoopExpression : public ScopeExpression {
    std::vector<Statement> statements;
    std::string chplLine;
 
+   bool isArrayInitForLoop = false;
+
    void emit(std::ostream & os) const;
 };
 

--- a/backend/include/hpx/programtreebuildingvisitor.hpp
+++ b/backend/include/hpx/programtreebuildingvisitor.hpp
@@ -25,6 +25,7 @@
 #include <variant>
 #include <vector>
 #include <queue>
+#include <map>
 
 using namespace chplx::ast::hpx;
 using namespace chpl;
@@ -51,7 +52,8 @@ struct ProgramTreeBuildingVisitor {
 
    std::vector< std::vector<Statement> * > curStmts;
    std::optional<uast::AstTag> prevTag;
-   std::queue<std::optional<Symbol>> pendingArrayForLoopSymbols;
+   std::deque<std::optional<Symbol>> pendingArrayForLoopSymbols;
+   std::map<std::string, bool> pendingArrayForLoopSymbolsMap;
 
    static std::unordered_map<std::string, int> operatorEncoder;
 };

--- a/backend/include/hpx/programtreebuildingvisitor.hpp
+++ b/backend/include/hpx/programtreebuildingvisitor.hpp
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <queue>
 
 using namespace chplx::ast::hpx;
 using namespace chpl;
@@ -50,6 +51,7 @@ struct ProgramTreeBuildingVisitor {
 
    std::vector< std::vector<Statement> * > curStmts;
    std::optional<uast::AstTag> prevTag;
+   std::queue<std::optional<Symbol>> pendingArrayForLoopSymbols;
 
    static std::unordered_map<std::string, int> operatorEncoder;
 };

--- a/backend/include/hpx/symboltypes.hpp
+++ b/backend/include/hpx/symboltypes.hpp
@@ -311,6 +311,9 @@ struct array_kind : public funcbase_kind {
 struct func_kind : public funcbase_kind {
    bool is_iter;
    bool is_lambda;
+   bool isArrayInitForLoop = false;
+   std::string arrayIdentifier = ""; // used in array init for-loops
+   std::optional<Symbol> arraySym;
 };
 
 struct tuple_kind : public funcbase_kind {

--- a/backend/src/programtreebuildingvisitor.cpp
+++ b/backend/src/programtreebuildingvisitor.cpp
@@ -281,11 +281,11 @@ bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {
            std::string identifier{dynamic_cast<Identifier const*>(ast)->name().c_str()};
            std::optional<Symbol> varsym =
                symbolTable.find(symbolTableRef->id, identifier);
-
+           
            if (fle->isArrayInitForLoop)
            {
               auto arrayVarsym = pendingArrayForLoopSymbols.front();
-              pendingArrayForLoopSymbols.pop();
+              pendingArrayForLoopSymbols.pop_front();
               auto arrayIdentifier = arrayVarsym->identifier;
 
               auto varsymInsideForLoop = arrayVarsym;
@@ -1224,9 +1224,9 @@ bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {
                   std::optional<Symbol> arrayVarsym{};
 
                   // Search in parent scope for array variables
-                  if(!pendingArrayForLoopSymbols.empty()) {
+                  if(!pendingArrayForLoopSymbols.empty() && fle->isArrayInitForLoop) {
                      arrayVarsym = pendingArrayForLoopSymbols.front();
-                     pendingArrayForLoopSymbols.pop();
+                     pendingArrayForLoopSymbols.pop_front();
                      arrayIdentifier = arrayVarsym->identifier;
 
                      auto varsymInsideForLoop = arrayVarsym;
@@ -1445,7 +1445,18 @@ bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {
                            it->second.kind);
                        if (func_sym->isArrayInitForLoop)
                        {
-                          pendingArrayForLoopSymbols.push(func_sym->arraySym);
+                          const auto& candidate = func_sym->arraySym;
+                          const auto& candidateArrIdentifier = func_sym->arrayIdentifier;
+
+                          if (pendingArrayForLoopSymbolsMap.find(candidateArrIdentifier) !=
+                              pendingArrayForLoopSymbolsMap.end())
+                          {
+                              // Already added this symbol
+                              continue;
+                          }
+                          pendingArrayForLoopSymbolsMap[candidateArrIdentifier] = true;
+
+                          pendingArrayForLoopSymbols.push_back(candidate);
                        }
                         }
                      }

--- a/backend/src/programtreebuildingvisitor.cpp
+++ b/backend/src/programtreebuildingvisitor.cpp
@@ -281,6 +281,39 @@ bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {
            std::string identifier{dynamic_cast<Identifier const*>(ast)->name().c_str()};
            std::optional<Symbol> varsym =
                symbolTable.find(symbolTableRef->id, identifier);
+
+           if (fle->isArrayInitForLoop)
+           {
+              auto arrayVarsym = pendingArrayForLoopSymbols.front();
+              pendingArrayForLoopSymbols.pop();
+              auto arrayIdentifier = arrayVarsym->identifier;
+
+              auto varsymInsideForLoop = arrayVarsym;
+              std::string iteratorName = fle->iterator.identifier;
+              auto arrayIdentifierForLoopExpression =
+                  arrayIdentifier + "(" + iteratorName + ")";
+              std::vector<Statement>* cStmts = curStmts.back();
+              varsymInsideForLoop->kind = std::make_shared<func_kind>(func_kind{
+                  {symbolTable.symbolTableRef->id, {}, {}, {}}, true, false});
+
+              cStmts->emplace_back(std::make_shared<BinaryOpExpression>(
+                  BinaryOpExpression{{{symbolTableRef->id}, "=", ast}, {}}));
+              auto& bo =
+                  std::get<std::shared_ptr<BinaryOpExpression>>(cStmts->back());
+
+              bo->statements.emplace_back(
+
+                  VariableExpression{std::make_shared<Symbol>(Symbol{
+                      varsymInsideForLoop->kind,
+                      arrayIdentifierForLoopExpression,    // This is "arr(i)"
+                      {}, -1, false, symbolTableRef->id})});
+
+              bo->statements.emplace_back(
+                  VariableExpression{std::make_shared<Symbol>(*varsym)});
+
+              return true;
+           }
+
            if(varsym) { 
               if(fle->indexSet.size() < 2) {
                  fle->indexSet.emplace_back(VariableExpression{std::make_shared<Symbol>(*varsym)});
@@ -1187,21 +1220,65 @@ bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {
                   std::shared_ptr<ForLoopExpression> & fle =
                      std::get<std::shared_ptr<ForLoopExpression>>(curStmts[curStmts.size()-2]->back());
 
+                  std::string arrayIdentifier = "";
+                  std::optional<Symbol> arrayVarsym{};
+
+                  // Search in parent scope for array variables
+                  if(!pendingArrayForLoopSymbols.empty()) {
+                     arrayVarsym = pendingArrayForLoopSymbols.front();
+                     pendingArrayForLoopSymbols.pop();
+                     arrayIdentifier = arrayVarsym->identifier;
+
+                     auto varsymInsideForLoop = arrayVarsym;
+                     std::string iteratorName = fle->iterator.identifier;
+                     auto arrayIdentifierForLoopExpression = arrayIdentifier + "(" + iteratorName + ")";
+                     std::vector<Statement> * cStmts = curStmts.back();
+                     varsymInsideForLoop->kind = std::make_shared<func_kind>(func_kind{{
+                           symbolTable.symbolTableRef->id, {}, {}, {}}, true, false});
+                     cStmts->emplace_back(
+                              std::make_shared<BinaryOpExpression>(BinaryOpExpression{
+                                 {{symbolTableRef->id}, "=", ast}, {}
+                              })
+                           );
+                     auto & bo = std::get<std::shared_ptr<BinaryOpExpression>>(cStmts->back());
+
+                     
+                     bo->statements.emplace_back(
+                        
+                        VariableExpression{std::make_shared<Symbol>(Symbol{
+                           varsymInsideForLoop->kind,
+                           arrayIdentifierForLoopExpression, // This is "arr(i)"
+                           {}, -1, false, symbolTableRef->id
+                        })}
+                     );
+
+                     bo->statements.emplace_back(
+                        std::make_shared<BinaryOpExpression>(
+                           BinaryOpExpression{ {{symbolTableRef->id}, identifier, ast}, {} }
+                        )
+                     );
+
+                     auto & rhsOp = std::get<std::shared_ptr<BinaryOpExpression>>(bo->statements.back());
+                     curStmts.push_back(&(rhsOp->statements));
+                  }
+
+
                   if(fle->indexSet.size() < 2) {
                      fle->indexSet.emplace_back(
                         std::make_shared<BinaryOpExpression>(BinaryOpExpression{
                            {{symbolTableRef->id}, identifier, ast}, {}
                         })
                      );
-                  }
-                  else {
-                     cStmts->emplace_back(
-                        std::make_shared<BinaryOpExpression>(BinaryOpExpression{
-                           {{symbolTableRef->id}, identifier, ast}, {}
-                        })
-                     );
-                     auto & nbo = std::get<std::shared_ptr<BinaryOpExpression>>(cStmts->back());
-                     curStmts.push_back(&(nbo->statements));
+                  }else{
+                     if(!arrayVarsym) {
+                        cStmts->emplace_back(
+                           std::make_shared<BinaryOpExpression>(BinaryOpExpression{
+                              {{symbolTableRef->id}, identifier, ast}, {}
+                           })
+                        );
+                        auto & nbo = std::get<std::shared_ptr<BinaryOpExpression>>(cStmts->back());
+                        curStmts.push_back(&(nbo->statements));
+                     }
                   }
                }
                else if(1 < curStmts.size() && curStmts[curStmts.size()-2]->size() && std::holds_alternative<std::shared_ptr<ForallLoopExpression>>(curStmts[curStmts.size()-2]->back())) {
@@ -1335,6 +1412,7 @@ bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {
        std::string identifier =
           std::string{dynamic_cast<NamedDecl const*>(ast)->name().c_str()};
        std::optional<Symbol> varsym{};
+       std::optional<Symbol> varsymInsideForLoop{};
        symbolTable.find(symbolTableRef->id, identifier, varsym);
        bool stmt = true;
 
@@ -1344,6 +1422,35 @@ bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {
 
            fl->iterator = *varsym;
            stmt = false;
+
+           if (fl->isArrayInitForLoop)
+           {
+             // This is the iterator variable in an array init for-loop
+             // We need to find the target array variable from the parent scope
+             // Look for array variable in the parent scope that's being initialized
+             // Search in parent scope for array variables
+             auto parentScopeId = symbolTable.parentSymbolTableId;
+             std::optional<std::pair<std::map<std::string, Symbol>::iterator,
+                 std::map<std::string, Symbol>::iterator>>
+                 allSymbols = symbolTable.findPrefix(parentScopeId, "");
+             if (allSymbols.has_value())
+             {
+                     for (auto it = allSymbols->first; it != allSymbols->second;
+                          ++it)
+                     {
+                        if (std::holds_alternative<std::shared_ptr<func_kind>>(
+                                it->second.kind))
+                        {
+                       auto func_sym = std::get<std::shared_ptr<func_kind>>(
+                           it->second.kind);
+                       if (func_sym->isArrayInitForLoop)
+                       {
+                          pendingArrayForLoopSymbols.push(func_sym->arraySym);
+                       }
+                        }
+                     }
+             }
+           }
        }
        else if (1 < curStmts.size() && std::holds_alternative<std::shared_ptr<ForallLoopExpression>>( curStmts[curStmts.size()-2]->back() ) ) {
            std::shared_ptr<ForallLoopExpression> & fl =
@@ -1596,6 +1703,13 @@ bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {
        std::string identifier{"for" + emitChapelLine(ast)};
        std::optional<Symbol> varsym =
           symbolTable.find(symbolTableRef->id, identifier);
+       bool isArrayInitForLoop = false;
+      
+      if(!varsym) {
+         identifier = "array_init_for" + emitChapelLine(ast);
+         varsym = symbolTable.find(symbolTableRef->id, identifier);
+         if(varsym.has_value()) isArrayInitForLoop = true;
+      }
 
        if(varsym.has_value() && std::holds_alternative<std::shared_ptr<func_kind>>(varsym->kind)) {
           std::vector<Statement> * cStmts = curStmts.back();
@@ -1605,7 +1719,7 @@ bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {
 
           cStmts->emplace_back(
              std::make_shared<ForLoopExpression>(
-                ForLoopExpression{{{fk->lutId}, ast, {}}, *varsym, {}, {}, {}, emitChapelLine(ast)}
+                ForLoopExpression{{{fk->lutId}, ast, {}}, *varsym, {}, {}, {}, emitChapelLine(ast),isArrayInitForLoop}
           ));
 
           auto & fndecl = std::get<std::shared_ptr<ForLoopExpression>>(cStmts->back());

--- a/backend/src/symbolbuildingvisitor.cpp
+++ b/backend/src/symbolbuildingvisitor.cpp
@@ -1317,32 +1317,75 @@ std::cout << "BLOCK HERE" << std::endl;
     {
         // symbol.scopePtr = the scope where the function is defined (equivalent to a lutId)
         //
-        symstack.emplace_back(
-           Symbol{{
-              std::make_shared<func_kind>(func_kind{{
-                 symbolTable.symbolTableRef->id, {}, {}, {}}}),
-              std::string{"for" + emitChapelLine(ast)},
-              {}, -1, false, symbolTable.symbolTableRef->id
-        }});
+       bool isArrayInitExpr = symnode    // we have a current AST node
+           && symnode->tag() == asttags::Variable    // that is a `var …` decl
+           && std::holds_alternative<std::shared_ptr<array_kind>>(
+                  sym->get().kind);    // whose kind is still array
 
-        std::shared_ptr<SymbolTable::SymbolTableNode> prevSymbolTableRef = symbolTable.symbolTableRef;
-        const std::size_t parScope = symbolTable.symbolTableRef->id;
+       if (std::holds_alternative<std::shared_ptr<array_kind>>(
+               sym->get().kind) &&
+           isArrayInitExpr)
+       {
+          // This is a for-loop expression used to initialize an array
+          std::shared_ptr<array_kind>& arrk =
+              std::get<std::shared_ptr<array_kind>>(sym->get().kind);
 
-        symbolTable.pushScope();
-        sym.reset();
-        sym = symstack.back();
+          // Mark this as an array initialization for-loop
+          symstack.emplace_back(
+              Symbol{{std::make_shared<func_kind>(func_kind{
+                          {symbolTable.symbolTableRef->id, {}, {}, {}}, false,
+                          false, true, sym->get().identifier, sym}),
+                  std::string{"array_init_for" + emitChapelLine(ast)}, {}, -1,
+                  false, symbolTable.symbolTableRef->id}});
 
-        std::shared_ptr<func_kind> & fk = 
-           std::get<std::shared_ptr<func_kind>>(sym->get().kind);
+          std::shared_ptr<SymbolTable::SymbolTableNode> prevSymbolTableRef =
+              symbolTable.symbolTableRef;
+          const std::size_t parScope = symbolTable.symbolTableRef->id;
+          symbolTable.pushScope();
 
-        fk->symbolTableSignature = sym->get().identifier;
-        // func_kind.lutId = the scope where the function's symboltable references
-        //
-        fk->lutId = symbolTable.symbolTableRef->id;
+          auto prevSym = sym;
+          sym.reset();
+          sym = symstack.back();
 
-        symbolTable.parentSymbolTableId = parScope;
-        symbolTable.symbolTableRef->parent = prevSymbolTableRef;
-        symnode = const_cast<uast::AstNode*>(ast);
+          std::shared_ptr<func_kind>& fk =
+              std::get<std::shared_ptr<func_kind>>(sym->get().kind);
+
+          fk->symbolTableSignature = sym->get().identifier;
+          fk->lutId = symbolTable.symbolTableRef->id;
+
+          symbolTable.parentSymbolTableId = parScope;
+          symbolTable.symbolTableRef->parent = prevSymbolTableRef;
+
+          symnode = const_cast<uast::AstNode*>(ast);
+       }
+        else{
+         symstack.emplace_back(
+            Symbol{{
+               std::make_shared<func_kind>(func_kind{{
+                  symbolTable.symbolTableRef->id, {}, {}, {}}}),
+               std::string{"for" + emitChapelLine(ast)},
+               {}, -1, false, symbolTable.symbolTableRef->id
+         }});
+
+         std::shared_ptr<SymbolTable::SymbolTableNode> prevSymbolTableRef = symbolTable.symbolTableRef;
+         const std::size_t parScope = symbolTable.symbolTableRef->id;
+
+         symbolTable.pushScope();
+         sym.reset();
+         sym = symstack.back();
+
+         std::shared_ptr<func_kind> & fk = 
+            std::get<std::shared_ptr<func_kind>>(sym->get().kind);
+
+         fk->symbolTableSignature = sym->get().identifier;
+         // func_kind.lutId = the scope where the function's symboltable references
+         //
+         fk->lutId = symbolTable.symbolTableRef->id;
+
+         symbolTable.parentSymbolTableId = parScope;
+         symbolTable.symbolTableRef->parent = prevSymbolTableRef;
+         symnode = const_cast<uast::AstNode*>(ast);
+      }
     }
     break;
     case asttags::Forall:

--- a/backend/test/forall.chpl
+++ b/backend/test/forall.chpl
@@ -66,3 +66,13 @@ coforall tid in 0..2 do
 
 for i in 0..2 do
    inlinecxx("std::cout << {} << std::endl;", C[i]);
+
+
+var D : [0..2] int = for i in 0..2 do
+  i;
+
+var E : [0..2] int = for i in 0..2 do
+  i+1;
+
+var F : [0..2] int = for i in 0..2 do
+  i+1 + i+1;

--- a/backend/test/forall.chpl
+++ b/backend/test/forall.chpl
@@ -76,3 +76,11 @@ var E : [0..2] int = for i in 0..2 do
 
 var F : [0..2] int = for i in 0..2 do
   i+1 + i+1;
+
+var G : [0..2] int;
+
+for i in 0..2 do
+  G[i] = i+1 + i+1;
+
+var H : [0..2] int = for j in 0..2 do
+  j+1 + j+1;

--- a/backend/test/forall/forall.cpp.good
+++ b/backend/test/forall/forall.cpp.good
@@ -105,6 +105,27 @@ namespace forall {
 #line 68 "forall.chpl"
             std::cout << C(i) << std::endl;
         });
+#line 71 "forall.chpl"
+        chplx::Array<std::int64_t, chplx::Domain<1>> D(chplx::Range(0, 2));
+#line 71 "forall.chpl"
+        chplx::forLoop(chplx::Range{0, 2}, [&](auto i) {
+#line 72 "forall.chpl"
+            D(i) = i;
+        });
+#line 74 "forall.chpl"
+        chplx::Array<std::int64_t, chplx::Domain<1>> E(chplx::Range(0, 2));
+#line 74 "forall.chpl"
+        chplx::forLoop(chplx::Range{0, 2}, [&](auto i) {
+#line 75 "forall.chpl"
+            E(i) = i + 1;
+        });
+#line 77 "forall.chpl"
+        chplx::Array<std::int64_t, chplx::Domain<1>> F(chplx::Range(0, 2));
+#line 77 "forall.chpl"
+        chplx::forLoop(chplx::Range{0, 2}, [&](auto i) {
+#line 78 "forall.chpl"
+            F(i) = ((i + 1) + i) + 1;
+        });
 
         delete exec;
     }

--- a/backend/test/forall/forall.cpp.good
+++ b/backend/test/forall/forall.cpp.good
@@ -126,6 +126,20 @@ namespace forall {
 #line 78 "forall.chpl"
             F(i) = ((i + 1) + i) + 1;
         });
+#line 80 "forall.chpl"
+        chplx::Array<std::int64_t, chplx::Domain<1>> G(chplx::Range(0, 2));
+#line 82 "forall.chpl"
+        chplx::forLoop(chplx::Range{0, 2}, [&](auto i) {
+#line 83 "forall.chpl"
+            G(i) = ((i + 1) + i) + 1;
+        });
+#line 85 "forall.chpl"
+        chplx::Array<std::int64_t, chplx::Domain<1>> H(chplx::Range(0, 2));
+#line 85 "forall.chpl"
+        chplx::forLoop(chplx::Range{0, 2}, [&](auto j) {
+#line 86 "forall.chpl"
+            H(j) = ((j + 1) + j) + 1;
+        });
 
         delete exec;
     }


### PR DESCRIPTION
This patch adds support for Chapel’s “array init with for-loop” syntax, e.g.:

  var arr: [0..2] int = for i in 0..2 do i+1;

Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>